### PR TITLE
Draft: remove support for v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FASwiftUI
 
-Easily integrate FontAwesome 5 or 6 into your SwiftUI projects. Use Font Awesome icons as text in your SwiftUI views. Supports Font Awesome Pro or Free.
+Easily integrate FontAwesome 6 into your SwiftUI projects. Use Font Awesome icons as text in your SwiftUI views. Supports FontAwesome Pro or Free.
 
 (Does not currently support the Duotone style.)
 
@@ -13,17 +13,15 @@ Easily integrate FontAwesome 5 or 6 into your SwiftUI projects. Use Font Awesome
     1. Go to https://fontawesome.com/download
     2. Download the Pro or Free version
 3. Drag the following files from the download to your project:
-    * icons.json
-    AND EITHER
-        * Font Awesome 6 Brands-Regular-400.otf
-        * Font Awesome 6 [Free/Pro]-Regular-400.otf
-        * Font Awesome 6 [Free/Pro]-Solid-900.otf
-        * Font Awesome 6 Pro-Light-300.otf (Pro Only)
-    OR
-        * Font Awesome 5 Brands-Regular-400.otf
-        * Font Awesome 5 [Free/Pro]-Regular-400.otf
-        * Font Awesome 5 [Free/Pro]-Solid-900.otf
-        * Font Awesome 5 Pro-Light-300.otf (Pro Only)
+    * /metadata/icon-families.json
+    * /otfs/Font Awesome 6 Brands-Regular-400.otf
+    * /otfs/Font Awesome 6 Pro-Light-300.otf (Pro Only)
+    * /otfs/Font Awesome 6 [Pro/Free]-Regular-400.otf
+    * /otfs/Font Awesome 6 [Pro/Free]-Solid-900.otf
+    * /otfs/Font Awesome 6 Pro-Thin-100.otf (Pro Only)
+    * /otfs/Font Awesome 6 Sharp-Light-300.otf (Pro Only)
+    * /otfs/Font Awesome 6 Sharp-Regular-400.otf (Pro Only)
+    * /otfs/Font Awesome 6 Sharp-Solid-900.otf (Pro Only)
 4. Add files to target - For each of the files in the last step:
     1. Select the file in Project Navigator
     2. Open the Inspectors bar on the right and select the file inspector (first tab)

--- a/Sources/FASwiftUI/FAIcon.swift
+++ b/Sources/FASwiftUI/FAIcon.swift
@@ -17,6 +17,7 @@ public enum FAStyle: String, Codable {
     case regular
     case solid
     case brands
+    case sharp
     case duotone
     // FA6 added thin style
     case thin
@@ -44,10 +45,7 @@ enum FACollection: String {
     case pro = "Font Awesome 6 Pro"
     case free = "Font Awesome 6 Free"
     case brands = "Font Awesome 6 Brands"
-    // FA5 backwards compatibility
-    case pro5 = "Font Awesome 5 Pro"
-    case free5 = "Font Awesome 5 Free"
-    case brands5 = "Font Awesome 5 Brands"
+    case sharp = "Font Awesome 6 Sharp"
 
     static var availableCollection: [FACollection] {
         var result = [FACollection]()
@@ -59,6 +57,9 @@ enum FACollection: String {
         }
         if FACollection.isAvailable(collection: .brands) || FACollection.isAvailable(collection: .brands5) {
             result.append(.brands)
+        }
+        if FACollection.isAvailable(collection: .sharp) {
+            result.append(.sharp)
         }
         return result
     }
@@ -93,6 +94,8 @@ public struct FAIcon: Identifiable, Decodable, Comparable {
     var collection: FACollection {
         if styles.contains(.brands) {
             return .brands
+        } else if styles.contains(.sharp) {
+            return .sharp
         } else if FACollection.isAvailable(collection: .pro) {
             return .pro
         } else {

--- a/Sources/FASwiftUI/FAIcon.swift
+++ b/Sources/FASwiftUI/FAIcon.swift
@@ -49,13 +49,13 @@ enum FACollection: String {
 
     static var availableCollection: [FACollection] {
         var result = [FACollection]()
-        if FACollection.isAvailable(collection: .pro) || FACollection.isAvailable(collection: .pro5) {
+        if FACollection.isAvailable(collection: .pro) {
             result.append(.pro)
         }
-        if FACollection.isAvailable(collection: .free) || FACollection.isAvailable(collection: .free5) {
+        if FACollection.isAvailable(collection: .free) {
             result.append(.free)
         }
-        if FACollection.isAvailable(collection: .brands) || FACollection.isAvailable(collection: .brands5) {
+        if FACollection.isAvailable(collection: .brands) {
             result.append(.brands)
         }
         if FACollection.isAvailable(collection: .sharp) {

--- a/Sources/FASwiftUI/FAText.swift
+++ b/Sources/FASwiftUI/FAText.swift
@@ -25,22 +25,6 @@ public struct FAText: View {
         
         if let icon = FontAwesome.shared.icon(byName: self.iconName) {
             self.icon = icon
-        } else {
-            // Many FA5 names change in FA6 and old names added to aliases array
-            if let iconAlias = FontAwesome.shared.icon(byAlias: self.iconName) {
-                self.icon = iconAlias
-            } else {
-                // Backwards compatibility for FA5 vs FA6 as font ID for circle-question has changed
-                // if icon not found use FA5 question-circle
-                if let iconFailed5 = FontAwesome.shared.icon(byName: "question-circle") {
-                    self.icon = iconFailed5
-                } else {
-                    // if question-circle not found use FA6 circle-question
-                    self.icon = FontAwesome.shared.icon(byName: "circle-question")!
-                }
-            }
-            self.style = .regular
-            print("FASwiftUI: Icon \"\(iconName)\" not found. Check list at https://fontawesome.com/icons for set availability.")
         }
         
         if !self.icon.styles.contains(self.style) {

--- a/Sources/FASwiftUI/FontAwesome.swift
+++ b/Sources/FASwiftUI/FontAwesome.swift
@@ -27,7 +27,7 @@ public class FontAwesome {
     // ======================================================= //
     
     init() {
-        let fileURL = Bundle.main.url(forResource: "icons", withExtension: "json")!
+        let fileURL = Bundle.main.url(forResource: "icon-families", withExtension: "json")!
         let jsonString = try! String(contentsOf: fileURL, encoding: .utf8)
         let jsonData = jsonString.data(using: .utf8)!
         let decoder = JSONDecoder()


### PR DESCRIPTION
- `icons.json` has been deprecated in favor of `icons-families.json`
- i couldn't find a way to swap these out without breaking backwards compatibility