### PR TITLE
Ensure Icon is fully displayed

### DIFF
--- a/Sources/FASwiftUI/FAText.swift
+++ b/Sources/FASwiftUI/FAText.swift
@@ -58,5 +58,7 @@ public struct FAText: View {
         Text(icon.unicodeString)
             .font(Font.custom(icon.collection.rawValue, size: size))
             .fontWeight(weight)
+            .lineLimit(1)
+            .fixedSize()
     }
 }


### PR DESCRIPTION
FAText is a wrapper around a Text View, which means that by default the Text can be truncated, unlike an image icon. This PR changes that behavior to ensure the Icon is fully displayed.